### PR TITLE
Hide the automatically generated files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+MYMETA.*
+Makefile*
+blib/
+cover_db/
+pm_to_blib


### PR DESCRIPTION
This allows the `git status` command to report a clean working directory.

This PR is submitted in the hope that it is useful.  Any questions or comments concerning it are more than welcome!