### PR TITLE
Skip cover_db/, vim backup and .swp files from MANIFEST

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,5 +1,9 @@
 ^blib
 ^pm_to_blib
+^cover_db
 .*\.old$
 ^Makefile$
 ^\.git
+~$
+.*\.swp$
+MANIFEST.SKIP


### PR DESCRIPTION
Also skip the MANIFEST.SKIP file itself: the `03-manifest.t` test which
checks the manifest was complaining that the MANIFEST.SKIP wasn't in the
MANIFEST, which it doesn't need to be (and was in fact removed from the
MANIFEST in a recent commit), hence the MANIFEST.SKIP should also skip
itself.  Now the RELEASE_TESTING tests pass.