### PR TITLE
Quieten perlcritic errors for strict/warnings

### DIFF
--- a/lib/MojoX/Transaction/WebSocket76.pm
+++ b/lib/MojoX/Transaction/WebSocket76.pm
@@ -1,5 +1,7 @@
 package MojoX::Transaction::WebSocket76;
 
+# Mojo::Base implicitly uses strict and warnings, so quieten perlcritic
+## no critic (RequireUseStrict, RequireUseWarnings)
 use Mojo::Util ('md5_bytes');
 
 use Mojo::Base 'Mojo::Transaction::WebSocket';


### PR DESCRIPTION
Mojo::Base already enables the `use strict` and `use warnings` pragmas,
hence one doesn't need to explicitly specify these.  In order to keep
perlcritic quiet on this issue, tell it not to require strict and warnings.