### PR TITLE
Fix for Mojolicious 6.40 and above

### DIFF
--- a/lib/MojoX/Transaction/WebSocket76.pm
+++ b/lib/MojoX/Transaction/WebSocket76.pm
@@ -3,19 +3,11 @@ package MojoX::Transaction::WebSocket76;
 use Mojo::Util ('md5_bytes');
 
 use Mojo::Base 'Mojo::Transaction::WebSocket';
-
+use Mojo::WebSocket qw(WS_TEXT WS_CLOSE);
 
 our $VERSION = '0.04';
 
-
-use constant DEBUG => &Mojo::Transaction::WebSocket::DEBUG;
-
-use constant {
-	TEXT   => &Mojo::Transaction::WebSocket::TEXT,
-	BINARY => &Mojo::Transaction::WebSocket::BINARY,
-	CLOSE  => &Mojo::Transaction::WebSocket::CLOSE,
-};
-
+use constant DEBUG => $Mojo::WebSocket::DEBUG;
 
 sub build_frame {
 	my ($self, undef, undef, undef, undef, $type, $bytes) = @_;
@@ -26,7 +18,7 @@ sub build_frame {
 
 	warn("-- Payload (" . length($bytes) . ")\n" . $bytes . "\n") if DEBUG;
 
-	return "\xff" if $type == CLOSE;
+	return "\xff" if $type == WS_CLOSE;
 	return "\x00" . $bytes . "\xff";
 }
 
@@ -37,7 +29,7 @@ sub parse_frame {
 
 	return if $index < 0;
 
-	my $type   = $index == 0 ? CLOSE : TEXT;
+	my $type   = $index == 0 ? WS_CLOSE : WS_TEXT;
 	my $length = $index - 1;
 	my $bytes  = $length
 			? substr(substr($$buffer, 0, $index + 1, ''), 1, $length)

--- a/lib/MojoX/Transaction/WebSocket76.pm
+++ b/lib/MojoX/Transaction/WebSocket76.pm
@@ -46,7 +46,7 @@ sub parse_frame {
 	warn("-- Parsing frame (undef, undef, undef, undef, " . $type . ")\n") if DEBUG;
 	warn("-- Payload (" . $length . ")\n" . $bytes . "\n") if DEBUG;
 
-	# Result does compatible with Mojo::Transaction::WebSocket.
+	# Result is compatible with Mojo::Transaction::WebSocket.
 	return [1, 0, 0, 0, $type, $bytes];
 }
 
@@ -104,7 +104,7 @@ sub _challenge {
 1;
 
 
-package # Hide form PAUSE.
+package # Hide from PAUSE.
 	MojoX::Transaction::WebSocket76::_Response;
 
 use Mojo::Base 'Mojo::Message::Response';


### PR DESCRIPTION
Update the module to use the new location for the constants previously imported from `Mojo::Transation::WebSocket`.  Their new location is now `Mojo::WebSocket`.  This PR makes the tests pass for Mojolicious versions 6.40 and above (and hence addresses issue #3), however breaks the code for Mojolicious versions below 6.40...  Do you also wish to support the older versions in any future release of `MojoX::Transaction::WebSocket76`?

It turns out that the `build_frame` method has also been moved from `Mojo::Transation::WebSocket` into `Mojo::WebSocket` and it has consequently been deprecated.  How exactly this issue is to be solved is not clear, however it is good to at least be aware that the method may one day be removed.