### PR TITLE
Add Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: perl
+
+perl:
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm Mojolicious~"<=6.39" || { cat ~/.cpanm/build.log ; false ; }
+    - cpanm --installdeps . || { cat ~/.cpanm/build.log ; false ; }
+    - cpanm Test::CheckManifest || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - perl Makefile.PL
+    - RELEASE_TESTING=1 make test

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -7,3 +7,4 @@
 ~$
 .*\.swp$
 MANIFEST.SKIP
+.travis.yml


### PR DESCRIPTION
This adds support for the [Travis-CI](https://travis-ci.org) continuous
integration service.  The service is free for open source projects and can
be used to test Perl distributions on various Perl versions.

If PR #12 is accepted, then the Mojolicious version restriction (line 13 of `.travis.yml`) can be removed.
If PR #7 is accepted, then `TEST_POD=1` can be added to the test command (line 19 of `.travis.yml`).

This PR is submitted in the hope that it is useful.  If you have any questions or comments concerning it please don't hesitate to ask!